### PR TITLE
don't encode utf NUL in json

### DIFF
--- a/src/com/paulasmuth/sqltap/JSONWriter.scala
+++ b/src/com/paulasmuth/sqltap/JSONWriter.scala
@@ -86,7 +86,7 @@ class JSONWriter(buf: WrappedBuffer) {
         buf.write(Array(0x5C.toByte, 0x22.toByte)) // \"
       } else if (b == 0x5C) {
         buf.write(Array(0x5C.toByte, 0x5C.toByte)) // \\
-      } else if ((b == 0) || ((b >= 0x20))) {
+      } else if (b >= 0x20) {
         buf.write(byte)
       }
     }


### PR DESCRIPTION
sqltap encodes UTF-8 NUL in the JSON response, which can't be parsed. It's causing these errors: https://bugsnag.com/dawanda-gmbh/loveos-frontend/errors/558be2086b8d2dd06f8bbc22 (ignore the naming of the error, the client is currently treating JSON parse errors as not found). Here's an example request where the response contains NUL http://10.10.47.12:7002/query?q=translation.findOne(1421028363)%7Btext%7D. Please take a look @christianparpart.
