### PR TITLE
add escaping for default_order field

### DIFF
--- a/src/main/scala/com/paulasmuth/sqltap/ResourceManifest.scala
+++ b/src/main/scala/com/paulasmuth/sqltap/ResourceManifest.scala
@@ -31,7 +31,7 @@ class ResourceManifest(doc: xml.Node) {
     elem.attr("id_field", false, "id")
 
   val default_order : String =
-    elem.attr("default_order", false, id_field + " DESC")
+    elem.attr("default_order", false, "`" + id_field + "` DESC")
 
   val relations =
     ((List[ResourceRelation]() /: (doc \ "relation"))


### PR DESCRIPTION
Fixes this one (when you try to specify the value `key` for `id_field` in a config):

``` json
{"status": "error","error": "SQL error (10495): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'key DESC' at line 1"}
```

@christianparpart 
