### PR TITLE
Allow empty value for SCHEMA_URL

### DIFF
--- a/bootup.sh
+++ b/bootup.sh
@@ -3,8 +3,8 @@ set -e
 
 SQLTAP_JARFILE="/usr/lib/sqltap.jar"
 
-if [[ "$SCHEMA_URL" != "" ]]; then
-  curl -sL "$SCHEMA_URL" -o "${SQLTAP_SCHEMA}"
+if [[ $SCHEMA_URL == http* ]]; then
+  curl -sL $SCHEMA_URL -o "${SQLTAP_SCHEMA}"
 fi
 
 require_arg() {


### PR DESCRIPTION
Before this change it was not possible to override the `SQLTAP_SCHEMA`
with a custom value for trying things out in development, because this
script would download the schema from the dist server and overwrite it,
or exit with an error on [line 17][17] if SCHEMA_URL was set to an empty
string.

[17]: https://github.com/dawanda/sqltap/blob/master/bootup.sh#L17