### PR TITLE
Add closing single quote to NotFoundException

### DIFF
--- a/src/main/scala/com/paulasmuth/sqltap/Exceptions.scala
+++ b/src/main/scala/com/paulasmuth/sqltap/Exceptions.scala
@@ -28,7 +28,7 @@ class NotFoundException(cur: Instruction = null) extends Exception {
     if (cur == null)
       "not found"
     else
-      "could not find record '" +
-      (if (cur.relation == null) "null" else cur.relation.name) +
-      (if (cur.record.has_id) "' with id #" + cur.record.id.toString else "")
+      "could not find record " +
+      (if (cur.relation == null) "null" else "'" + cur.relation.name + "'") +
+      (if (cur.record.has_id) " with id #" + cur.record.id.toString else "")
 }


### PR DESCRIPTION
before: [ERROR] could not find record 'orders
after:  [ERROR] could not find record 'orders'